### PR TITLE
Add backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,16 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-18.04
+    name: Backport
+    steps:
+      - name: Backport
+        uses: m-kuhn/backport@v1.2.7
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Allows for easy backporting of pull requests. Simply just label a pull request with e.g. `backport 1.2` to create a backport PR against the `1.2` branch.

For more info, see https://github.com/m-kuhn/backport