### PR TITLE
ændret EPSG:4230 til 2D

### DIFF
--- a/webproj/data.json
+++ b/webproj/data.json
@@ -189,8 +189,8 @@
         "v1_short": "ϕ",
         "v2": "Længdegrad",
         "v2_short": "λ",
-        "v3":"Ellipsoidehøjde",
-        "v3_short":"h",
+        "v3": null,
+        "v3_short": null,
         "v4": null,
         "v4_short": null
     },


### PR DESCRIPTION
4230 var ved en fejl skrevet med højdekote.
v3 er nu null sammen med de tilhørende værdier.