### PR TITLE
Fix backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,10 +7,12 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: Backport
     steps:
-      - name: Backport
+      - name: Backport Bot
+        id: backport
+        if: github.event.pull_request.merged && ( ( github.event.action == 'closed' && contains( join( github.event.pull_request.labels.*.name ), 'backport') ) || contains( github.event.label.name, 'backport' ) )
         uses: m-kuhn/backport@v1.2.7
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It doesn't run due to an old base-image. From now on it always runs on `ubuntu-latest`. Updated to latest version of the action.